### PR TITLE
Strict Typescript output of discriminator (PHNX-805)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
@@ -145,10 +145,10 @@ export class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{
 {{/vars}}
 
     {{#discriminator}}
-    static discriminator = {{discriminator}};
+    static discriminator: string | undefined = "{{discriminator}}";
     {{/discriminator}}
     {{^discriminator}}
-    static discriminator = undefined;
+    static discriminator: string | undefined = undefined;
     {{/discriminator}}
 
     {{^isArrayModel}}

--- a/samples/client/petstore/typescript-node/default/api.ts
+++ b/samples/client/petstore/typescript-node/default/api.ts
@@ -144,7 +144,7 @@ export class ApiResponse {
     'type'?: string;
     'message'?: string;
 
-    static discriminator = undefined;
+    static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
@@ -175,7 +175,7 @@ export class Category {
     'id'?: number;
     'name'?: string;
 
-    static discriminator = undefined;
+    static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
@@ -208,7 +208,7 @@ export class Order {
     'status'?: Order.StatusEnum;
     'complete'?: boolean;
 
-    static discriminator = undefined;
+    static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
@@ -268,7 +268,7 @@ export class Pet {
     */
     'status'?: Pet.StatusEnum;
 
-    static discriminator = undefined;
+    static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
@@ -321,7 +321,7 @@ export class Tag {
     'id'?: number;
     'name'?: string;
 
-    static discriminator = undefined;
+    static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {
@@ -356,7 +356,7 @@ export class User {
     */
     'userStatus'?: number;
 
-    static discriminator = undefined;
+    static discriminator: string | undefined = undefined;
 
     static attributeTypeMap: Array<{name: string, baseName: string, type: string}> = [
         {


### PR DESCRIPTION
Motivation
----
The current release of swagger-codegen does not output valid strict typescript for discriminators

Modifications
----
Updating the discriminator output to be valid strict typescript

https://centeredge.atlassian.net/browse/PHNX-805