### PR TITLE
Make SwaggerCodeGen serialize subclasses properly (PHNX-851)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
@@ -79,6 +79,9 @@ class ObjectSerializer {
                 return data;
             }
 
+            // Get the actual type of this object
+            type = this.findCorrectType(data, type);
+
             // get the map for the correct type.
             let attributeTypes = typeMap[type].getAttributeTypeMap();
             let instance: {[index: string]: any} = {};

--- a/samples/client/petstore/typescript-node/default/api.ts
+++ b/samples/client/petstore/typescript-node/default/api.ts
@@ -88,6 +88,9 @@ class ObjectSerializer {
                 return data;
             }
 
+            // Get the actual type of this object
+            type = this.findCorrectType(data, type);
+
             // get the map for the correct type.
             let attributeTypes = typeMap[type].getAttributeTypeMap();
             let instance: {[index: string]: any} = {};


### PR DESCRIPTION
Motivation
----
Previously, when serializing as subclass of a property, generated swagger clients would only serialize properties of the parent class causing some values to not be pass through

Modifications
----
Before serializing attributes of a given type, we check to see if there is a specific type to be serialized so that we don't miss any properties.

https://centeredge.atlassian.net/browse/PHNX-851