### PR TITLE
Make SwaggerCodeGen serialize subclasses properly (PHNX-851)

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-node/api.mustache
@@ -47,7 +47,12 @@ class ObjectSerializer {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
-                    return data[discriminatorProperty]; // use the type given in the discriminator
+                    var discriminatorType = data[discriminatorProperty];
+                    if(typeMap[discriminatorType]){
+                        return data[discriminatorProperty]; // use the type given in the discriminator
+                    } else {
+                        return expectedType; // discriminator did not map to a type
+                    }
                 } else {
                     return expectedType; // discriminator was not present (or an empty string)
                 }
@@ -78,6 +83,9 @@ class ObjectSerializer {
             if (!typeMap[type]) { // in case we dont know the type
                 return data;
             }
+
+            // Get the actual type of this object
+            type = this.findCorrectType(data, type);
 
             // get the map for the correct type.
             let attributeTypes = typeMap[type].getAttributeTypeMap();

--- a/samples/client/petstore/typescript-node/default/api.ts
+++ b/samples/client/petstore/typescript-node/default/api.ts
@@ -56,7 +56,12 @@ class ObjectSerializer {
                 return expectedType; // the type does not have a discriminator. use it.
             } else {
                 if (data[discriminatorProperty]) {
-                    return data[discriminatorProperty]; // use the type given in the discriminator
+                    var discriminatorType = data[discriminatorProperty];
+                    if(typeMap[discriminatorType]){
+                        return data[discriminatorProperty]; // use the type given in the discriminator
+                    } else {
+                        return expectedType; // discriminator did not map to a type
+                    }
                 } else {
                     return expectedType; // discriminator was not present (or an empty string)
                 }
@@ -87,6 +92,9 @@ class ObjectSerializer {
             if (!typeMap[type]) { // in case we dont know the type
                 return data;
             }
+
+            // Get the actual type of this object
+            type = this.findCorrectType(data, type);
 
             // get the map for the correct type.
             let attributeTypes = typeMap[type].getAttributeTypeMap();


### PR DESCRIPTION
Motivation
----
Previously, when serializing as subclass of a property, generated swagger clients would only serialize properties of the parent class causing some values to not be pass through

Modifications
----
Before serializing attributes of a given type, we check to see if there is a specific type to be serialized so that we don't miss any properties.

https://centeredge.atlassian.net/browse/PHNX-851